### PR TITLE
feat: add starknet support

### DIFF
--- a/src/codegen/types/conversions.js
+++ b/src/codegen/types/conversions.js
@@ -313,6 +313,13 @@ const ASSEMBLYSCRIPT_TO_VALUE = [
 ]
 
 /**
+ * starknet -> AssemblyScript conversions
+ */
+ const STARKNET_VALUE_TO_ASSEMBLYSCRIPT = [
+  ['felt', 'Bytes', code => `${code}`],
+]
+
+/**
  * Type conversions
  */
 module.exports = immutable.fromJS({
@@ -325,5 +332,8 @@ module.exports = immutable.fromJS({
   },
   Value: {
     AssemblyScript: VALUE_TO_ASSEMBLYSCRIPT,
+  },
+  starknet: {
+    AssemblyScript: STARKNET_VALUE_TO_ASSEMBLYSCRIPT,
   },
 })

--- a/src/codegen/types/conversions.js
+++ b/src/codegen/types/conversions.js
@@ -320,6 +320,13 @@ const ASSEMBLYSCRIPT_TO_VALUE = [
 ]
 
 /**
+ * AssemblyScript -> starknet conversions
+ */
+ const ASSEMBLYSCRIPT_TO_STARKNET_VALUE = [
+  ['Bytes', 'felt', code => `${code}`],
+]
+
+/**
  * Type conversions
  */
 module.exports = immutable.fromJS({
@@ -329,6 +336,7 @@ module.exports = immutable.fromJS({
   AssemblyScript: {
     ethereum: ASSEMBLYSCRIPT_TO_ETHEREUM_VALUE,
     Value: ASSEMBLYSCRIPT_TO_VALUE,
+    starknet: ASSEMBLYSCRIPT_TO_STARKNET_VALUE,
   },
   Value: {
     AssemblyScript: VALUE_TO_ASSEMBLYSCRIPT,

--- a/src/codegen/types/index.js
+++ b/src/codegen/types/index.js
@@ -84,6 +84,9 @@ const ethereumToAsc = (code, ethereumType, internalType) =>
     internalType,
   )
 
+const protocolFromAsc = (protocol, code, protocolType) =>
+    findConversionToType('AssemblyScript', protocol, protocolType).get('convert')(code)
+
 const ethereumFromAsc = (code, ethereumType) =>
   findConversionToType('AssemblyScript', 'ethereum', ethereumType).get('convert')(code)
 
@@ -102,6 +105,7 @@ const valueFromAsc = (code, valueType) =>
 module.exports = {
   // protocol <-> AssemblyScript
   ascTypeForProtocol,
+  protocolFromAsc,
 
   // ethereum <-> AssemblyScript
   ascTypeForEthereum,

--- a/src/command-helpers/scaffold.js
+++ b/src/command-helpers/scaffold.js
@@ -102,7 +102,7 @@ const writeSchema = async (abi, protocol, schemaPath, entities) => {
     : []
 
   let data = prettier.format(
-    events.map(event => generateEventType(event, protocol.name)).join('\n\n'),
+    events.map(event => generateEventType(event, protocol)).join('\n\n'),
     {
       parser: 'graphql',
     },

--- a/src/protocols/index.js
+++ b/src/protocols/index.js
@@ -144,7 +144,7 @@ module.exports = class Protocol {
       case 'cosmos':
         return false
       case 'starknet':
-        return false
+        return true
     }
   }
 
@@ -159,7 +159,7 @@ module.exports = class Protocol {
       case 'cosmos':
         return false
       case 'starknet':
-        return false
+        return true
     }
   }
 
@@ -284,6 +284,22 @@ module.exports = class Protocol {
         return CosmosMappingScaffold
       case 'starknet':
         return StarknetMappingScaffold
+    }
+  }
+
+  // quick & dirty fix to replace tight coupling to ethereum abi spec for abi events
+  getEventParams(event) {
+    switch (this.name) {
+      case 'arweave':
+        return null
+      case 'ethereum':
+        return event.inputs
+      case 'near':
+        return null
+      case 'cosmos':
+        return null
+      case 'starknet':
+        return event.data
     }
   }
 }

--- a/src/protocols/index.js
+++ b/src/protocols/index.js
@@ -10,6 +10,8 @@ const StarknetSubgraph = require('./starknet/subgraph')
 const EthereumContract = require('./ethereum/contract')
 const NearContract = require('./near/contract')
 const StarknetContract = require('./starknet/contract')
+const StarknetTypeGenerator = require('./starknet/type-generator')
+const StarknetABI = require('./starknet/abi')
 const EthereumManifestScaffold = require('./ethereum/scaffold/manifest')
 const NearManifestScaffold = require('./near/scaffold/manifest')
 const CosmosManifestScaffold = require('./cosmos/scaffold/manifest')
@@ -127,8 +129,7 @@ module.exports = class Protocol {
       case 'cosmos':
         return false
       case 'starknet':
-        // TODO: support ABI
-        return false
+        return true
     }
   }
 
@@ -143,7 +144,6 @@ module.exports = class Protocol {
       case 'cosmos':
         return false
       case 'starknet':
-        // TODO: support contracts
         return false
     }
   }
@@ -159,7 +159,6 @@ module.exports = class Protocol {
       case 'cosmos':
         return false
       case 'starknet':
-        // TODO: support events
         return false
     }
   }
@@ -175,7 +174,7 @@ module.exports = class Protocol {
       case 'cosmos':
         return false
       case 'starknet':
-        return true
+        return false
     }
   }
 
@@ -190,8 +189,7 @@ module.exports = class Protocol {
       case 'cosmos':
         return null
       case 'starknet':
-        // TODO: support type generation
-        return null
+        return new StarknetTypeGenerator(options)
     }
   }
 
@@ -221,7 +219,7 @@ module.exports = class Protocol {
       case 'cosmos':
         return null
       case 'starknet':
-        return null
+        return StarknetABI
     }
   }
 

--- a/src/protocols/starknet/abi.js
+++ b/src/protocols/starknet/abi.js
@@ -1,0 +1,50 @@
+const fs = require('fs-extra')
+const immutable = require('immutable')
+const path = require('path')
+
+const AbiCodeGenerator = require('./codegen/abi')
+
+module.exports = class ABI {
+  constructor(name, file, data) {
+    this.name = name
+    this.file = file
+    this.data = data
+  }
+
+  codeGenerator() {
+    return new AbiCodeGenerator(this)
+  }
+
+  static eventSignature(event) {
+    return `${event.get('name')}(${event
+      .get('data', [])
+      .map(property => property.get('type'))
+      .join(',')})`
+  }
+
+  static normalized(json) {
+    if (Array.isArray(json)) {
+      return json
+    } else if (json.abi !== undefined) {
+      return json.abi
+    } else if (
+      json.compilerOutput !== undefined &&
+      json.compilerOutput.abi !== undefined
+    ) {
+      return json.compilerOutput.abi
+    } else {
+      return undefined
+    }
+  }
+
+  static load(name, file) {
+    let data = JSON.parse(fs.readFileSync(file))
+    let abi = ABI.normalized(data)
+
+    if (abi === null || abi === undefined) {
+      throw Error(`No valid ABI in file: ${path.relative(process.cwd(), file)}`)
+    }
+
+    return new ABI(name, file, immutable.fromJS(abi))
+  }
+}

--- a/src/protocols/starknet/abi.js
+++ b/src/protocols/starknet/abi.js
@@ -16,10 +16,7 @@ module.exports = class ABI {
   }
 
   static eventSignature(event) {
-    return `${event.get('name')}(${event
-      .get('data', [])
-      .map(property => property.get('type'))
-      .join(',')})`
+    return event.get('name');
   }
 
   static normalized(json) {

--- a/src/protocols/starknet/codegen/abi.js
+++ b/src/protocols/starknet/codegen/abi.js
@@ -1,0 +1,121 @@
+const tsCodegen = require('../../../codegen/typescript')
+const typesCodegen = require('../../../codegen/types')
+const util = require('../../../codegen/util')
+
+module.exports = class AbiCodeGenerator {
+  constructor(abi) {
+    this.abi = abi
+  }
+
+  generateModuleImports() {
+    let imports = [
+      tsCodegen.moduleImports(
+        [
+          'starknet',
+          'Bytes',
+        ],
+        '@graphprotocol/graph-ts',
+      )
+    ]
+    return imports
+  }
+
+  generateTypes() {
+    return [
+      ...this._generateEventTypes(),
+    ]
+  }
+
+  _generateEventTypes() {
+    // Enumerate events with duplicate names
+    
+    let events = util.disambiguateNames({
+      values: this.abi.data.filter(member => member.get('type') === 'event'),
+      getName: event => event.get('name'),
+      setName: (event, name) => event.set('_alias', name),
+    })
+
+    events = events
+      .map(event => {
+        let eventClassName = event.get('_alias')
+
+        // First, generate a class with the event data getters
+        let paramsClassName = eventClassName + '__Params'
+        let paramsClass = tsCodegen.klass(paramsClassName, { export: true })
+        paramsClass.addMember(tsCodegen.klassMember('_event', eventClassName))
+        paramsClass.addMethod(
+          tsCodegen.method(
+            `constructor`,
+            [tsCodegen.param(`event`, eventClassName)],
+            null,
+            `this._event = event`,
+          ),
+        )
+        
+        // Enumerate data with duplicate names
+        let eventProperties = util.disambiguateNames({
+          values: event.get('data'),
+          getName: (property) => property.get('name'),
+          setName: (property, name) => property.set('name', name),
+        })
+
+        eventProperties.forEach((property, index) => {
+          // Generate getters for event data
+          // Only support getter for felt => Bytes
+          if (property.get('type') !== 'felt') {
+            return;
+          }
+
+          let paramObject = this._generateEventGetter(
+            property,
+            index,
+          )
+
+          paramsClass.addMethod(paramObject.getter)
+        })
+
+        // Then, generate the event class itself
+        let klass = tsCodegen.klass(eventClassName, {
+          export: true,
+          extends: 'starknet.Event',
+        })
+
+        klass.addMethod(
+          tsCodegen.method(
+            `get params`,
+            [],
+            tsCodegen.namedType(paramsClassName),
+            `return new ${paramsClassName}(this)`,
+          ),
+        )
+
+        return [klass, paramsClass]
+      })
+
+    return events
+      .reduce(
+        // flatten the array
+        (array, classes) => array.concat(classes),
+        [],
+      )
+  }
+
+  _generateEventGetter(event, index) {
+    // Get name and type of the param, adjusting for indexed params and missing names
+    let name = event.get('name')
+    let valueType = event.get('type')
+
+    // Only felts -> Bytes is supported
+    // Generate getters for the param
+    return {
+      name: [],
+      getter: tsCodegen.method(
+        `get ${name}`,
+        [],
+        typesCodegen.ascTypeForProtocol('starknet', valueType), 
+        `return this._event.data[${index}]`,
+      ),
+      classes: [],
+    }
+  }
+}

--- a/src/protocols/starknet/manifest.graphql
+++ b/src/protocols/starknet/manifest.graphql
@@ -29,6 +29,7 @@ type DataSource {
 
 type ContractSource {
   startBlock: BigInt
+  address: String
 }
 
 type ContractMapping {

--- a/src/protocols/starknet/manifest.graphql
+++ b/src/protocols/starknet/manifest.graphql
@@ -37,9 +37,15 @@ type ContractMapping {
   language: String!
   file: File!
   entities: [String!]!
+  abis: [ContractAbi!]!
   blockHandlers: [BlockHandler!]
   eventHandlers: [EventHandler!]
   transactionHandlers: [TransactionHandler!]
+}
+
+type ContractAbi {
+  name: String!
+  file: File!
 }
 
 type TransactionHandler {

--- a/src/protocols/starknet/scaffold/manifest.js
+++ b/src/protocols/starknet/scaffold/manifest.js
@@ -1,14 +1,30 @@
-const source = () => `
+const { abiEvents } = require('../../../scaffold/schema')
+const { strings } = require('gluegun')
+const ABI = require('../abi')
+
+const source = ({ contract, contractName }) => `
+      address: '${contract}'
       startBlock: 0`
 
-const mapping = () => `
-      apiVersion: 0.0.5
+const mapping = ({ abi, contractName }) => `
+      apiVersion: 0.0.6
       language: wasm/assemblyscript
       entities:
-        - ExampleEntity
-      blockHandlers:
-        - handler: handleBlock
-      file: ./src/contract.ts`
+        ${abiEvents(abi)
+          .map(event => `- ${event.get('_alias')}`)
+          .join('\n        ')}
+      abis:
+        - name: ${contractName}
+          file: ./abis/${contractName}.json
+      eventHandlers:
+        ${abiEvents(abi)
+          .map(
+            event => `
+        - event: ${ABI.eventSignature(event)}
+          handler: handle${event.get('_alias')}`,
+          )
+          .join('')}
+      file: ./src/${strings.kebabCase(contractName)}.ts`
 
 module.exports = {
   source,

--- a/src/protocols/starknet/scaffold/mapping.js
+++ b/src/protocols/starknet/scaffold/mapping.js
@@ -1,35 +1,67 @@
-const generatePlaceholderHandlers = () =>
+const generateFieldAssignment = path =>
+  `entity.${path.join('_')} = event.params.${path.join('.')}`
+
+const generateFieldAssignments = ({ index, input }) =>
+  input.type === 'tuple'
+    ? util
+        .unrollTuple({ value: input, index, path: [input.name || `param${index}`] })
+        .map(({ path }) => generateFieldAssignment(path))
+    : generateFieldAssignment([input.name || `param${index}`])
+
+const generateEventFieldAssignments = event =>
+  event.data.reduce(
+    (acc, input, index) => acc.concat(generateFieldAssignments({ input, index })),
+    [],
+  )
+
+const generatePlaceholderHandlers = ({ abi, events, contractName }) =>
   `
-  import { starknet, BigInt } from "@graphprotocol/graph-ts"
-  import { ExampleEntity } from "../generated/schema"
+  import { BigInt } from "@graphprotocol/graph-ts"
+  import { ${events.map(event => event._alias)} }
+    from '../generated/${contractName}/${contractName}'
+  import { ExampleEntity } from '../generated/schema'
 
-  export function handleBlock(block: starknet.Block): void {
-    // Entities can be loaded from the store using a string ID; this ID
-    // needs to be unique across all entities of the same type
-    let entity = ExampleEntity.load(block.hash.toHex())
+  ${events
+    .map((event, index) =>
+      index === 0
+        ? `
+    export function handle${event._alias}(event: ${event._alias}): void {
+      if (!event.data.length) {
+        return
+      }
 
-    // Entities only exist after they have been saved to the store;
-    // \`null\` checks allow to create entities on demand
-    if (!entity) {
-      entity = new ExampleEntity(block.hash.toHex())
+      // Entities can be loaded from the store using a string ID; this ID
+      // needs to be unique across all entities of the same type
+      let entity = ExampleEntity.load(event.data[0].toHex())
 
-      // Entity fields can be set using simple assignments
-      entity.count = block.height
+      // Entities only exist after they have been saved to the store;
+      // \`null\` checks allow to create entities on demand
+      if (!entity) {
+        entity = new ExampleEntity(event.data[0].toHex())
+      }
+
+      entity.count = new BigInt(1)
+
+      // Entity fields can be set based on event parameters
+      ${generateEventFieldAssignments(event)
+        .slice(0, 2)
+        .join('\n')}
+
+      // Entities can be written to the store with \`.save()\`
+      entity.save()
+
+      // Note: If a handler doesn't require existing field values, it is faster
+      // _not_ to load the entity from the store. Instead, create it fresh with
+      // \`new Entity(...)\`, set the fields that should be updated and save the
+      // entity back to the store. Fields that were not set or unset remain
+      // unchanged, allowing for partial updates to be applied.
     }
-
-    // Entity fields can be set based on receipt information
-    entity.block = block.prevHash
-
-    // Entities can be written to the store with \`.save()\`
-    entity.save()
-
-    // Note: If a handler doesn't require existing field values, it is faster
-    // _not_ to load the entity from the store. Instead, create it fresh with
-    // \`new Entity(...)\`, set the fields that should be updated and save the
-    // entity back to the store. Fields that were not set or unset remain
-    // unchanged, allowing for partial updates to be applied.
-  }
-`
+    `
+        : `
+export function handle${event._alias}(event: ${event._alias}): void {}
+`,
+    )
+    .join('\n')}`
 
 module.exports = {
   generatePlaceholderHandlers,

--- a/src/protocols/starknet/type-generator.js
+++ b/src/protocols/starknet/type-generator.js
@@ -1,0 +1,201 @@
+const fs = require('fs-extra')
+const path = require('path')
+const immutable = require('immutable')
+const prettier = require('prettier')
+const ABI = require('./abi')
+const { step, withSpinner } = require('../../command-helpers/spinner')
+const { GENERATED_FILE_NOTE } = require('../../codegen/typescript')
+const { displayPath } = require('../../command-helpers/fs')
+
+module.exports = class StarknetTypeGenerator {
+  constructor(options = {}) {
+    this.sourceDir = options.sourceDir
+    this.outputDir = options.outputDir
+  }
+
+  async loadABIs(subgraph) {
+    return await withSpinner(
+      'Load contract ABIs',
+      'Failed to load contract ABIs',
+      `Warnings while loading contract ABIs`,
+      async spinner => {
+        try {
+          return subgraph
+            .get('dataSources')
+            .reduce(
+              (abis, dataSource) =>
+              dataSource
+              .getIn(['mapping', 'abis'])
+              .reduce(
+                (abis, abi) =>
+                abis.push(
+                  this._loadABI(
+                    dataSource,
+                    abi.get('name'),
+                    abi.get('file'),
+                    spinner,
+                  ),
+                ),
+                abis,
+              ),
+              immutable.List(),
+            )
+        } catch (e) {
+          throw Error(`Failed to load contract ABIs: ${e.message}`)
+        }
+      },
+    )
+  }
+
+  _loadABI(dataSource, name, maybeRelativePath, spinner) {
+    try {
+      if (this.sourceDir) {
+        let absolutePath = path.resolve(this.sourceDir, maybeRelativePath)
+        step(spinner, `Load contract ABI from`, displayPath(absolutePath))
+        return { dataSource: dataSource, abi: ABI.load(name, absolutePath) }
+      } else {
+        return { dataSource: dataSource, abi: ABI.load(name, maybeRelativePath) }
+      }
+    } catch (e) {
+      throw Error(`Failed to load contract ABI: ${e.message}`)
+    }
+  }
+
+  async loadDataSourceTemplateABIs(subgraph) {
+    return await withSpinner(
+      `Load data source template ABIs`,
+      `Failed to load data source template ABIs`,
+      `Warnings while loading data source template ABIs`,
+      async spinner => {
+        let abis = []
+        for (let template of subgraph.get('templates', immutable.List())) {
+          for (let abi of template.getIn(['mapping', 'abis'])) {
+            abis.push(
+              this._loadDataSourceTemplateABI(
+                template,
+                abi.get('name'),
+                abi.get('file'),
+                spinner,
+              ),
+            )
+          }
+        }
+        return abis
+      },
+    )
+  }
+
+  _loadDataSourceTemplateABI(template, name, maybeRelativePath, spinner) {
+    try {
+      if (this.sourceDir) {
+        let absolutePath = path.resolve(this.sourceDir, maybeRelativePath)
+        step(
+          spinner,
+          `Load data source template ABI from`,
+          displayPath(absolutePath),
+        )
+        return { template, abi: ABI.load(name, absolutePath) }
+      } else {
+        return { template, abi: ABI.load(name, maybeRelativePath) }
+      }
+    } catch (e) {
+      throw Error(`Failed to load data source template ABI: ${e.message}`)
+    }
+  }
+
+  generateTypesForABIs(abis) {
+    return withSpinner(
+      `Generate types for contract ABIs`,
+      `Failed to generate types for contract ABIs`,
+      `Warnings while generating types for contract ABIs`,
+      async spinner => {
+        return await Promise.all(
+          abis.map(async (abi, name) => await this._generateTypesForABI(abi, spinner)),
+        )
+      },
+    )
+  }
+
+  async _generateTypesForABI(abi, spinner) {
+    try {
+      step(
+        spinner,
+        `Generate types for contract ABI:`,
+        `${abi.abi.name} (${displayPath(abi.abi.file)})`,
+      )
+      let codeGenerator = abi.abi.codeGenerator()
+      let code = prettier.format(
+        [
+          GENERATED_FILE_NOTE,
+          ...codeGenerator.generateModuleImports(),
+          ...codeGenerator.generateTypes(),
+        ].join('\n'),
+        {
+          parser: 'typescript',
+        },
+      )
+      let outputFile = path.join(
+        this.outputDir,
+        abi.dataSource.get('name'),
+        `${abi.abi.name}.ts`,
+      )
+      step(spinner, `Write types to`, displayPath(outputFile))
+      await fs.mkdirs(path.dirname(outputFile))
+      await fs.writeFile(outputFile, code)
+    } catch (e) {
+      throw Error(`Failed to generate types for contract ABI: ${e.message}`)
+    }
+  }
+
+  async generateTypesForDataSourceTemplateABIs(abis) {
+    return await withSpinner(
+      `Generate types for data source template ABIs`,
+      `Failed to generate types for data source template ABIs`,
+      `Warnings while generating types for data source template ABIs`,
+      async spinner => {
+        return await Promise.all(
+          abis.map(
+            async (abi, name) =>
+              await this._generateTypesForDataSourceTemplateABI(abi, spinner),
+          ),
+        )
+      },
+    )
+  }
+
+  async _generateTypesForDataSourceTemplateABI(abi, spinner) {
+    try {
+      step(
+        spinner,
+        `Generate types for data source template ABI:`,
+        `${abi.template.get('name')} > ${abi.abi.name} (${displayPath(
+          abi.abi.file,
+        )})`,
+      )
+
+      let codeGenerator = abi.abi.codeGenerator()
+      let code = prettier.format(
+        [
+          GENERATED_FILE_NOTE,
+          ...codeGenerator.generateModuleImports(),
+          ...codeGenerator.generateTypes(),
+        ].join('\n'),
+        {
+          parser: 'typescript',
+        },
+      )
+
+      let outputFile = path.join(
+        this.outputDir,
+        'templates',
+        abi.template.get('name'),
+        `${abi.abi.name}.ts`,
+      )
+      step(spinner, `Write types to`, displayPath(outputFile))
+      await fs.mkdirs(path.dirname(outputFile))
+      await fs.writeFile(outputFile, code)
+    } catch (e) {
+      throw Error(`Failed to generate types for data source template ABI: ${e.message}`)
+    }
+  }
+}

--- a/src/scaffold/index.js
+++ b/src/scaffold/index.js
@@ -90,7 +90,7 @@ dataSources:
     return prettier.format(
       hasEvents && this.indexEvents
         ? events.map(
-            event => generateEventType(event, this.protocol.name)
+            event => generateEventType(event, this.protocol)
           )
             .join('\n\n')
         : generateExampleEntityType(this.protocol, events),
@@ -149,7 +149,7 @@ dataSources:
       : []
 
     return events.length > 0
-      ?  generateTestsFiles(this.contractName, events, this.indexEvents)
+      ?  generateTestsFiles(this.contractName, events, this.indexEvents, this.protocol)
       : undefined
   }
 

--- a/src/scaffold/schema.js
+++ b/src/scaffold/schema.js
@@ -23,11 +23,11 @@ const generateEventFields = ({ index, input, protocolName }) =>
         .map(({ path, type }) => generateField({ name: path.join('_'), type, protocolName }))
     : [generateField({ name: input.name || `param${index}`, type: input.type, protocolName })]
 
-const generateEventType = (event, protocolName) => `type ${event._alias} @entity {
+const generateEventType = (event, protocol) => `type ${event._alias} @entity {
       id: ID!
-      ${event.inputs
+      ${protocol.getEventParams(event)
         .reduce(
-          (acc, input, index) => acc.concat(generateEventFields({ input, index, protocolName })),
+          (acc, input, index) => acc.concat(generateEventFields({ input, index, protocolName: protocol.name })),
           [],
         )
         .join('\n')}
@@ -38,7 +38,7 @@ const generateExampleEntityType = (protocol, events) => {
       return `type ExampleEntity @entity {
   id: ID!
   count: BigInt!
-  ${events[0].inputs
+  ${protocol.getEventParams(events[0])
     .reduce((acc, input, index) => acc.concat(generateEventFields({ input, index, protocolName: protocol.name })), [])
     .slice(0, 2)
     .join('\n')}


### PR DESCRIPTION
This allows the use of `yarn codegen` for starknet subgraphs to automatically generate types for starknet events using an ABI. 

It also enables the `--abi` and `--from-contract` flags to be used with `graph init` for starknet contracts, so the scaffolds for manifest and mapping files are generated using the abi.